### PR TITLE
Updated my_neuron_model.py

### DIFF
--- a/python_models/neuron/neuron_models/my_neuron_model.py
+++ b/python_models/neuron/neuron_models/my_neuron_model.py
@@ -85,7 +85,7 @@ class MyNeuronModel(AbstractNeuronModel):
         # TODO: update to match the number of global parameters
         # Note: This must match the number of parameters in the global_neuron_t
         # data structure in the C code
-        return 1
+        return 3
 
     @inject_items({"machine_time_step": "MachineTimeStep"})
     def get_global_parameters(self, machine_time_step):

--- a/python_models/neuron/threshold_types/my_threshold_type.py
+++ b/python_models/neuron/threshold_types/my_threshold_type.py
@@ -48,7 +48,7 @@ class MyThresholdType(AbstractThresholdType):
         # TODO: update to return the number of parameters
         # Note: This must match the number of values in the threshold_type_t
         # data structure in the C code
-        return 1
+        return 2
 
     def get_threshold_parameters(self):
 


### PR DESCRIPTION
Updated def get_n_global_parameters(self) to return 3 parameters instead of 1 to prevent the following error when running example.py:

2017-02-26 00:50:42 ERROR: Error executing data specification for 0, 0, 2
Traceback (most recent call last):
…
data_specification.exceptions.DataSpecificationNoMoreException: Space unavailable to write all the elements requested by the write operation. Space available: 0; space requested: 4 for region 1.